### PR TITLE
add comment link to github pages

### DIFF
--- a/metrics/Committers.md
+++ b/metrics/Committers.md
@@ -1,5 +1,7 @@
 # Committers
 
+[Comment on Release Candidate](https://github.com/chaoss/wg-risk/issues/16)
+
 ## 1. Description
 The Committers metric is the number of individuals who have committed code to a project. This is distinct from the more broadly construed "Contributors" CHAOSS metric, speaking directly to the one specific concern that arises in the evaluation of risk by managers deciding which open source project to use.  While not necessarily true in all cases, it is generally accepted that the more contributors there are to a project, the more likely that project is to continue to receive updates, support, and necessary resources. The metric therefore allows organizations to make an informed decision as to whether the number of committers to a given project potentially poses a current or future risk that the project may be abandoned or under-supported.
 

--- a/metrics/Elephant_Factor.md
+++ b/metrics/Elephant_Factor.md
@@ -1,5 +1,7 @@
 # Elephant Factor
 
+[Comment on Release Candidate](https://github.com/chaoss/wg-risk/issues/15)
+
 ## 1. Description
 The minimum number of companies whose employees perform a parameterizable definition of the total percentage of commits in a software repository is a project's 'elephant factor'. For example, one common filter is to say the elephant factor is to say 50% of the commits are performed by `n companies` and that is the elephant factor. One would begin adding up to the parameterized percentage using the largest organizations making contributions, and then the next largest and so on. So, for example, a project with 8 contributing organizations who each contributed 12.5% of the commits in a project would, if the elephant factor is parameterized at 50%, have an elephant factor of "4". If one of those organizations was responsible for 50% of commits in the same scenario, then the elephant factor would be "1".
 

--- a/metrics/License_Count.md
+++ b/metrics/License_Count.md
@@ -1,5 +1,7 @@
 # License Count
 
+[Comment on Release Candidate](https://github.com/chaoss/wg-risk/issues/17)
+
 ## 1. Description
 The total count of identified licenses in a software package where the same license can be counted more than once if it is found in multiple source files. This can include both software and document related licenses. This metric also provides a binary indicator of whether or not the repository contains files without license declarations.  
 

--- a/metrics/License_Coverage.md
+++ b/metrics/License_Coverage.md
@@ -1,5 +1,7 @@
 # License Coverage
 
+[Comment on Release Candidate](https://github.com/chaoss/wg-risk/issues/18)
+
 ## 1. Description
 How much of the code base has declared licenses. This includes both software and documentation source files and is represented as a percentage of total coverage.
 

--- a/metrics/License_Declared.md
+++ b/metrics/License_Declared.md
@@ -1,5 +1,7 @@
 # License Declared
 
+[Comment on Release Candidate](https://github.com/chaoss/wg-risk/issues/19)
+
 ## 1. Description
 The total number and specific licenses declared in a software package. This can include both software and documentation source files.
 

--- a/metrics/Software_Bill_of_Materials.md
+++ b/metrics/Software_Bill_of_Materials.md
@@ -1,5 +1,7 @@
 # Bill of Materials
 
+[Comment on Release Candidate](https://github.com/chaoss/wg-risk/issues/20)
+
 ## 1. Description
 A software package has a standard expression of dependencies, licensing, and security-related issues.
 

--- a/metrics/Test_Coverage.md
+++ b/metrics/Test_Coverage.md
@@ -1,5 +1,7 @@
 # Test Coverage
 
+[Comment on Release Candidate](https://github.com/chaoss/wg-risk/issues/23)
+
 ## 1. Description
 How much of a given code base is covered by at least one test suite. There are two principle measures of test coverage. One is the percentage of **subroutines** covered in a test suite run against a repository. The other principle expression of test coverage is the percentage of **statements** covered during the execution of a test suite. The CHAOSS metric definition for "Test Coverage" includes both of these discrete measures.
 


### PR DESCRIPTION
Signed-off-by: klumb <klumbard@unomaha.edu>

@GeorgLink, @germonprez,

I added the link at the top of the detail pages. If this is acceptable, I will duplicate this for all the release candidates.
