### PR TITLE
add "Open Source Metric"

### DIFF
--- a/metrics/License_Coverage.md
+++ b/metrics/License_Coverage.md
@@ -34,6 +34,8 @@ PercentTotalLicenseCoverage: {{ '%0.2f' %  ((cnt[0] / loop.index) * 100) | float
 ### Filters
 Time: Licenses declared in a repository can change over time as the dependencies of the repository change. One of the principle motivations for tracking license presence, aside from basic awareness, is to draw attention to any unexpected new license introduction.
 
+"Open Source Metric": Percentage of licenses on the list of Open Source Initiative (OSI) approved licenses over all found licenses. 
+
 ### Visualizations 
 
 #### Web Presentation of DoSOCS2 Output:

--- a/metrics/License_Coverage.md
+++ b/metrics/License_Coverage.md
@@ -49,4 +49,5 @@ Time: Licenses declared in a repository can change over time as the dependencies
 
 ## Resources
 * https://spdx.org/
+  * JSON of SPDX license list: https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json
 * https://www.fossology.org


### PR DESCRIPTION
The idea is to add a filter to License Coverage.
The filter check what percentage of licenses is listed of Open Source Initiative (OSI) approved licenses.
The SPDX license list provides that information.

The name of the metric that results from that filter is proposed to be "Open Source Metric" -- as coined during a conversation during All Things Open between Patrick, Nick (both from OSI) and Georg, Daniel (both Bitergia and CHAOSS board members).

