### PR TITLE
Update funding.yml to point to Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,10 +2,10 @@
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
+open_collective: chaoss
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: chaoss
+community_bridge: # Replace with a single Community Bridge username
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username


### PR DESCRIPTION
Updating to reflect switching to Open Collective for receiving and managing funds.

Signed-off-by: Marie <chefantons@gmail.com>