### PR TITLE
Updated: focus-areas/security/README.md (Spelling)

### DIFF
--- a/focus-areas/security/README.md
+++ b/focus-areas/security/README.md
@@ -6,5 +6,5 @@ Metric | Question
 --- | ---
 [OpenSSF Best Practices](openssf-best-practices.md) | What is the current OpenSSF Best Practices status for the project?
 [Language Declaration README](language-declaration-readme.md)| How many languages were used?
-[Language Source Proportion](language-source-proportion.md) | What is the proportion of language souces used?
+[Language Source Proportion](language-source-proportion.md) | What is the proportion of language sources used?
 


### PR DESCRIPTION
Fixed spelling: `souces` to `sources` 